### PR TITLE
Update PowerShell modules

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -28,6 +28,8 @@ packages:
     manager: winget
   - name: Microsoft.PowerShell
     manager: winget
+  - name: ajeetdsouza.zoxide
+    manager: winget
   - name: Microsoft.OpenSSH.Preview
     manager: winget
   - name: icsharpcode.ILSpy

--- a/packages.yaml
+++ b/packages.yaml
@@ -30,6 +30,8 @@ packages:
     manager: winget
   - name: ajeetdsouza.zoxide
     manager: winget
+  - name: junegunn.fzf
+    manager: winget
   - name: Microsoft.OpenSSH.Preview
     manager: winget
   - name: icsharpcode.ILSpy

--- a/powershell/manifest.yaml
+++ b/powershell/manifest.yaml
@@ -38,5 +38,5 @@ ps-modules:
   - Posh-Git
   - PSReadLine
   - zoxide
-  - PSYaml
+  - powershell-yaml
   - Git-NumberedAdd

--- a/powershell/manifest.yaml
+++ b/powershell/manifest.yaml
@@ -37,6 +37,6 @@ links:
 ps-modules:
   - Posh-Git
   - PSReadLine
-  - Jump.Location
+  - zoxide
   - PSYaml
   - Git-NumberedAdd

--- a/powershell/manifest.yaml
+++ b/powershell/manifest.yaml
@@ -40,3 +40,6 @@ ps-modules:
   - zoxide
   - powershell-yaml
   - Git-NumberedAdd
+  - Terminal-Icons
+  - PSFzf
+  - CompletionPredictor


### PR DESCRIPTION
## Summary
- Replace Jump.Location with zoxide (Rust-based, cross-shell, frecency algorithm)
- Replace PSYaml with powershell-yaml (more actively maintained, better PS7 support)
- Add Terminal-Icons, PSFzf, and CompletionPredictor as new modules
- Add zoxide and fzf as winget packages (required binaries for PS module wrappers)

## Test Plan
- [ ] `perch deploy` installs all new PS modules without errors
- [ ] `zoxide` initializes correctly in PS profile (needs `Invoke-Expression (& { (zoxide init powershell | Out-String) })`)
- [ ] `Terminal-Icons` shows icons in `ls` output (requires a Nerd Font)
- [ ] `PSFzf` Ctrl+R fuzzy history search works
- [ ] `CompletionPredictor` predictions appear in PSReadLine
- [ ] `powershell-yaml` ConvertFrom-Yaml/ConvertTo-Yaml work as drop-in for PSYaml